### PR TITLE
Fix implicit children type error in react18

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "@commitlint/config-conventional": "^13.1.0",
     "graphql": "^16.2.0",
     "next": "^11.1.2",
-    "react": "^17.0.2"
+    "react": "^18.1.0"
   },
   "peerDependencies": {
     "react": ">= 16.0.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "blocks",
-  "version": "1.1.6",
+  "version": "1.1.7",
   "description": "Libraries for building custom storefronts with BRIKL",
   "repository": "https://github.com/Brikl/blocks",
   "author": "Phumrapee Limpianchop <contact@rayriffy.com>",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@brikl/blocks-react",
-  "version": "1.1.6",
+  "version": "1.1.7",
   "description": "JavaScript API for creating custom BRIKL storefront",
   "contributors": [
     {

--- a/packages/react/src/core/types.ts
+++ b/packages/react/src/core/types.ts
@@ -1,9 +1,11 @@
 import type { FunctionComponent } from 'react'
 
-import type { ContextInitialize, CognitoConfig } from '@brikl/blocks'
+import type { ContextInitialize } from '@brikl/blocks'
+import React from 'react'
 
 export interface StorefrontProviderProps {
   config: ContextInitialize
+  children?: React.ReactElement
 }
 
 export type StorefrontProviderComponent =

--- a/packages/react/src/core/types.ts
+++ b/packages/react/src/core/types.ts
@@ -1,12 +1,10 @@
-import type { FunctionComponent } from 'react'
+import type { FC } from 'react'
 
 import type { ContextInitialize } from '@brikl/blocks'
-import React from 'react'
 
 export interface StorefrontProviderProps {
   config: ContextInitialize
   children?: React.ReactElement
 }
 
-export type StorefrontProviderComponent =
-  FunctionComponent<StorefrontProviderProps>
+export type StorefrontProviderComponent = FC<StorefrontProviderProps>

--- a/yarn.lock
+++ b/yarn.lock
@@ -8752,7 +8752,7 @@ nyc@^15.1.0:
 object-assign@^4, object-assign@^4.1.0, object-assign@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
-  integrity sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=
+  integrity sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==
 
 object-inspect@^1.11.0, object-inspect@^1.9.0:
   version "1.11.0"
@@ -9425,13 +9425,12 @@ react-refresh@0.8.3:
   resolved "https://registry.yarnpkg.com/react-refresh/-/react-refresh-0.8.3.tgz#721d4657672d400c5e3c75d063c4a85fb2d5d68f"
   integrity sha512-X8jZHc7nCMjaCqoU+V2I0cOhNW+QMBwSUkeXnTi8IPe6zaRWfn60ZzvFDZqWPfmSJfjub7dDW1SP0jaHWLu/hg==
 
-react@^17.0.2:
-  version "17.0.2"
-  resolved "https://registry.yarnpkg.com/react/-/react-17.0.2.tgz#d0b5cc516d29eb3eee383f75b62864cfb6800037"
-  integrity sha512-gnhPt75i/dq/z3/6q/0asP78D0u592D5L1pd7M8P+dck6Fu/jJeL6iVVK23fptSUZj8Vjf++7wXA8UNclGQcbA==
+react@^18.1.0:
+  version "18.2.0"
+  resolved "https://registry.yarnpkg.com/react/-/react-18.2.0.tgz#555bd98592883255fa00de14f1151a917b5d77d5"
+  integrity sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ==
   dependencies:
     loose-envify "^1.1.0"
-    object-assign "^4.1.1"
 
 read-pkg-up@^7.0.1:
   version "7.0.1"


### PR DESCRIPTION
React18 no longer uses implicit children in types. This update adds children to the props as React.ReactElement to avoid type errors.